### PR TITLE
Only update searchbar if text has changed

### DIFF
--- a/Sources/SwiftlySearch/SwiftlySearch.swift
+++ b/Sources/SwiftlySearch/SwiftlySearch.swift
@@ -73,10 +73,11 @@ struct SearchBar<ResultContent: View>: UIViewControllerRepresentable {
     class Coordinator: NSObject, UISearchResultsUpdating, UISearchBarDelegate {
         @Binding
         var text: String
-        var updatedText: String
         var cancelClicked: () -> Void
         var searchClicked: () -> Void
         let searchController: UISearchController
+
+        private var updatedText: String
 
         init(text: Binding<String>, placeholder: String?, hidesNavigationBarDuringPresentation: Bool, resultContent: (String) -> ResultContent?, cancelClicked: @escaping () -> Void, searchClicked: @escaping () -> Void) {
             self._text = text

--- a/Sources/SwiftlySearch/SwiftlySearch.swift
+++ b/Sources/SwiftlySearch/SwiftlySearch.swift
@@ -73,12 +73,14 @@ struct SearchBar<ResultContent: View>: UIViewControllerRepresentable {
     class Coordinator: NSObject, UISearchResultsUpdating, UISearchBarDelegate {
         @Binding
         var text: String
+        var updatedText: String
         var cancelClicked: () -> Void
         var searchClicked: () -> Void
         let searchController: UISearchController
 
         init(text: Binding<String>, placeholder: String?, hidesNavigationBarDuringPresentation: Bool, resultContent: (String) -> ResultContent?, cancelClicked: @escaping () -> Void, searchClicked: @escaping () -> Void) {
             self._text = text
+            updatedText = text.wrappedValue
             self.cancelClicked = cancelClicked
             self.searchClicked = searchClicked
 
@@ -106,8 +108,9 @@ struct SearchBar<ResultContent: View>: UIViewControllerRepresentable {
 
         // MARK: - UISearchResultsUpdating
         func updateSearchResults(for searchController: UISearchController) {
-            guard let text = searchController.searchBar.text else { return }
+            guard let text = searchController.searchBar.text, updatedText != text else { return }
             DispatchQueue.main.async {
+                self.updatedText = text
                 self.text = text
             }
         }
@@ -125,7 +128,6 @@ struct SearchBar<ResultContent: View>: UIViewControllerRepresentable {
     class SearchBarWrapperController: UIViewController {
         var text: String? {
             didSet {
-                guard oldValue != text else { return }
                 self.parent?.navigationItem.searchController?.searchBar.text = text
             }
         }

--- a/Sources/SwiftlySearch/SwiftlySearch.swift
+++ b/Sources/SwiftlySearch/SwiftlySearch.swift
@@ -109,7 +109,10 @@ struct SearchBar<ResultContent: View>: UIViewControllerRepresentable {
 
         // MARK: - UISearchResultsUpdating
         func updateSearchResults(for searchController: UISearchController) {
-            guard let text = searchController.searchBar.text, updatedText != text else { return }
+            guard let text = searchController.searchBar.text else { return }
+            // Make sure the text has actually changed (workaround for #10).
+            guard updatedText != text else { return }
+
             DispatchQueue.main.async {
                 self.updatedText = text
                 self.text = text

--- a/Sources/SwiftlySearch/SwiftlySearch.swift
+++ b/Sources/SwiftlySearch/SwiftlySearch.swift
@@ -107,8 +107,6 @@ struct SearchBar<ResultContent: View>: UIViewControllerRepresentable {
         // MARK: - UISearchResultsUpdating
         func updateSearchResults(for searchController: UISearchController) {
             guard let text = searchController.searchBar.text else { return }
-            // Make sure the text has actually changed (workaround for #10).
-            guard text != self.text else { return }
             DispatchQueue.main.async {
                 self.text = text
             }
@@ -127,6 +125,7 @@ struct SearchBar<ResultContent: View>: UIViewControllerRepresentable {
     class SearchBarWrapperController: UIViewController {
         var text: String? {
             didSet {
+                guard oldValue != text else { return }
                 self.parent?.navigationItem.searchController?.searchBar.text = text
             }
         }

--- a/Tests/TestApp/TestViews/ObservablePublishedTest.swift
+++ b/Tests/TestApp/TestViews/ObservablePublishedTest.swift
@@ -1,7 +1,17 @@
+import Combine
 import SwiftUI
 
 class ObservablePublishedModel: ObservableObject {
     @Published var searchText = ""
+    @Published var updateCount = 0
+    var cancellable: Cancellable?
+
+    init() {
+        cancellable = $searchText
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink() { [weak self] _ in self?.updateCount += 1 }
+    }
 }
 
 struct ObservablePublishedTest: View {
@@ -9,7 +19,8 @@ struct ObservablePublishedTest: View {
 
     var body: some View {
         List {
-            Text("foo")
+            Text("Update count: \(viewModel.updateCount)")
+                .accessibility(identifier: "countLabel")
         }
         .navigationBarSearch($viewModel.searchText)
     }

--- a/Tests/UITests/ObservablePublishedTests.swift
+++ b/Tests/UITests/ObservablePublishedTests.swift
@@ -1,17 +1,17 @@
-// I was unable to get this test to work, but I'm leaving it in as a reminder for the future.
+import Combine
+import XCTest
+@testable import TestApp
 
-//import XCTest
-//
-//class ObservablePublishedTests: UITest {
-//    func testObservablePublishedMetric() throws {
-//        selectTest("Observable Published")
-//
-//        measure(metrics: [XCTCPUMetric(application: app)]) {
-//            app.children(matching: .any).firstMatch.slowSwipeDown(offset: 0.5, distance: 0.1)
-//
-//            // Ensure the searchbar exists.
-//            let navBar = app.navigationBars.firstMatch
-//            XCTAssertTrue(navBar.children(matching: .searchField).firstMatch.exists, "Searchbar exists")
-//        }
-//    }
-//}
+class ObservablePublishedTests: UITest {
+
+    func testObservablePublishedMetric() throws {
+        selectTest("Observable Published")
+
+        app.children(matching: .any).firstMatch.slowSwipeDown(offset: 0.5, distance: 0.1)
+        let searchBar = app.navigationBars.firstMatch.children(matching: .searchField).firstMatch
+        searchBar.tap()
+        searchBar.typeText("h")
+
+        XCTAssertEqual(app.staticTexts["countLabel"].label, "Update count: 1")
+    }
+}

--- a/Tests/UITests/ObservablePublishedTests.swift
+++ b/Tests/UITests/ObservablePublishedTests.swift
@@ -10,8 +10,18 @@ class ObservablePublishedTests: UITest {
         app.children(matching: .any).firstMatch.slowSwipeDown(offset: 0.5, distance: 0.1)
         let searchBar = app.navigationBars.firstMatch.children(matching: .searchField).firstMatch
         searchBar.tap()
-        searchBar.typeText("h")
 
+        searchBar.typeText("h")
         XCTAssertEqual(app.staticTexts["countLabel"].label, "Update count: 1")
+
+        searchBar.typeText("e")
+        XCTAssertEqual(app.staticTexts["countLabel"].label, "Update count: 2")
+
+        searchBar.typeText("llo")
+        XCTAssertEqual(app.staticTexts["countLabel"].label, "Update count: 5")
+
+        searchBar.typeText(XCUIKeyboardKey.delete.rawValue)
+        searchBar.typeText(XCUIKeyboardKey.delete.rawValue)
+        XCTAssertEqual(app.staticTexts["countLabel"].label, "Update count: 7")
     }
 }


### PR DESCRIPTION
We can't count on accessing the updated value of the binding correctly until the swiftui view has completed it's update. If we trigger an update of the view off the change `self.text` continues to return the old value. 

Rather than check the binding against the current value, we can just make sure we don't change the `searchbar` text if it already has the new value.